### PR TITLE
Prise en compte des commandes action complexes

### DIFF
--- a/core/class/tydom.class.php
+++ b/core/class/tydom.class.php
@@ -299,13 +299,36 @@ class tydomCmd extends cmd {
       }
     }
 
-    $params = [
-      'action' => $action[0],
-      'endpoint_name' => $action[1],
-      'device_id' => $device[1],
-      'endpoint_id' => $device[0],
-      'value' => $value,
-    ];
+    
+    if (strpos($value, ":") !== false) {
+      $params = [
+        'action' => $action[0],
+        'endpoint_name' => $action[1],
+        'device_id' => $device[1],
+        'endpoint_id' => $device[0],
+        'parameters' => [],
+      ];
+
+      $values = explode("|", $value);
+      $parameters = array();
+      foreach ($values as $val) {
+        $val = explode(":", $val);
+        if (json_decode($val[1]) == null) {
+            $params['parameters'][$val[0]] = $val[1];
+        } else {
+            $params['parameters'][$val[0]] = json_decode($val[1]);
+        }
+      }
+    } else {
+      $params = [
+        'action' => $action[0],
+        'endpoint_name' => $action[1],
+        'device_id' => $device[1],
+        'endpoint_id' => $device[0],
+        'value' => $value,
+      ];
+    }
+    log::add('tydom', 'debug', "sendto_daemon : " . json_encode($params));
     tydom::sendto_daemon($params);
   }
 }

--- a/resources/tydomd/tydom/TydomClient.py
+++ b/resources/tydomd/tydom/TydomClient.py
@@ -8,6 +8,7 @@ import http.client
 import logging
 import os
 import ssl
+import json
 
 import websockets
 from requests.auth import HTTPDigestAuth
@@ -198,6 +199,45 @@ class TydomClient:
         logger.debug("Sending message to tydom (%s %s)", "PUT data", body)
         await self.connection.send(a_bytes)
         return 0
+
+    async def put_devices_cdata(self, device_id, endpoint_id, cmdName, parameters):
+        try:
+
+            logger.debug("put_devices_cdata")
+            body = (json.dumps(parameters))
+            logger.debug(body)
+
+            url = "PUT /devices/{device}/endpoints/{endpoint}/cdata?name={name}".format(
+                    device=str(device_id),
+                    endpoint=str(endpoint_id),
+                    name=str(cmdName))
+
+            logger.debug(
+                "URL : %s",
+                url)
+
+            str_request = (
+                self.cmd_prefix +
+                url + " HTTP/1.1\r\nContent-Length: " +
+                str(len(body)) +
+                "\r\nContent-Type: application/json; charset=UTF-8\r\nTransac-Id: 0\r\n\r\n" +
+                body +
+                "\r\n\r\n")
+
+            a_bytes = bytes(str_request, "ascii")
+            logger.debug(
+                "Sending message to tydom (%s %s)",
+                "PUT cdata",
+                body)
+
+            try:
+                await self.connection.send(a_bytes)
+                return 0
+            except BaseException:
+                logger.error("put_devices_cdata ERROR !", exc_info=True)
+                logger.error(a_bytes)
+        except BaseException:
+            logger.error("put_devices_cdata ERROR !", exc_info=True)
 
     async def put_alarm_cdata(self, device_id, alarm_id=None, value=None, zone_id=None):
 

--- a/resources/tydomd/tydomd.py
+++ b/resources/tydomd/tydomd.py
@@ -32,7 +32,10 @@ async def read_socket():
       return
 
     if message['action'] == 'set':
-      await tydom_client.put_devices_data(message['device_id'], message['endpoint_id'], message['endpoint_name'], message['value'])
+      if "parameters" in message:
+        await tydom_client.put_devices_cdata(message['device_id'], message['endpoint_id'], message['endpoint_name'], message['parameters'])
+      else:
+        await tydom_client.put_devices_data(message['device_id'], message['endpoint_id'], message['endpoint_name'], message['value'])
       return
 
     if message['action'] == 'poll':


### PR DESCRIPTION
Le code permet d’exécuter une commande avec un idLogic de la forme `set_partCmd:value:ON|part:1` ce qui permet de faire fonctionner complètemenbt mon alarme.
Il a fallu ajouter la méthode qui gere les put cdata sur TydomClient.py
Les commandes cdata ne sont pas (encore) crées automatiquement depuis le cmetadata.
Peut-être faudrait-il laisser l'utilisateur créer ses propres commandes ?